### PR TITLE
Flatpak shown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ For more detailed instructions check out the [installation process wiki page](ht
 ## Downloads
 Downloads can be found at the [Release Page](https://github.com/AM2R-Community-Developers/AM2RLauncher/releases).
 
+For Linux users, a [Flatpak](https://aur.archlinux.org/packages/am2rlauncher/) can be installed with all above dependecies bundled. This method is the reccomended way for [Steam Deck](https://www.steamdeck.com/en/) users.
+
 Alternatively, for Arch Linux users an [AUR Package](https://aur.archlinux.org/packages/am2rlauncher/) also exists. Install it with `makepkg -si` or use your favourite AUR helper.
 
 ## Configuration and Data Files

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For more detailed instructions check out the [installation process wiki page](ht
 ## Downloads
 Downloads can be found at the [Release Page](https://github.com/AM2R-Community-Developers/AM2RLauncher/releases).
 
-For Linux users, a [Flatpak](https://aur.archlinux.org/packages/am2rlauncher/) can be installed with all above dependecies bundled. This method is the reccomended way for [Steam Deck](https://www.steamdeck.com/en/) users.
+For all Linux users, a [Flatpak](https://flathub.org/apps/details/io.github.am2r_community_developers.AM2RLauncher) is available and can be installed with all above dependencies bundled. This method is the recommended way for Steam Deck users.
 
 Alternatively, for Arch Linux users an [AUR Package](https://aur.archlinux.org/packages/am2rlauncher/) also exists. Install it with `makepkg -si` or use your favourite AUR helper.
 


### PR DESCRIPTION
Added the newly released Flatpak installation method on the GitHub with a recommendation for steam deck users to install with said method.