### PR TITLE
Allow overriding NOAUTOUPDATE during the build

### DIFF
--- a/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
+++ b/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
@@ -12,6 +12,10 @@
     <Platforms>AnyCPU</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NoAutoUpdate)' == true">
+    <DefineConstants>$(DefineConstants);NOAUTOUPDATE</DefineConstants>
+  </PropertyGroup>
 	
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Even though there's a preprocessor conditional in the code to allow distro packagers to disable auto-updating, it cannot be easily accessed unless it's bound through in the `csproj` file.

On my Linux machine, this allows me to pass a `--property:NoAutoUpdate=true` flag to `dotnet` to disable autoupdate.