### PR TITLE
Port Mesa wrapper script from Autopatcher, patch openssl

### DIFF
--- a/AM2RLauncher/AM2RLauncher.Gtk/Program.cs
+++ b/AM2RLauncher/AM2RLauncher.Gtk/Program.cs
@@ -70,6 +70,10 @@ internal static class MainClass
         log.Info("On AppImage configuration.");
         #endif
 
+        #if PATCHOPENSSL
+        log.Info("On configuration for patching OpenSSL 1.0.0.");
+        #endif
+
         try
         {
             Application gtkLauncher = new Application(Eto.Platforms.Gtk);

--- a/AM2RLauncher/AM2RLauncherLib/Profile.cs
+++ b/AM2RLauncher/AM2RLauncherLib/Profile.cs
@@ -502,7 +502,7 @@ public static class Profile
             #endif
 
             File.Move($"{tempPath}/{exe}", $"{tempPath}/.runner-unwrapped");
-            File.Move($"{Core.PatchDataPath}/data/mesa-wrapper.sh", $"{tempPath}/runner");
+            File.Copy($"{Core.PatchDataPath}/data/mesa-wrapper.sh", $"{tempPath}/runner");
             #else
             // Copy AppImage template to here
             HelperMethods.DirectoryCopy($"{Core.PatchDataPath}/data/AM2R.AppDir", $"{tempPath}/AM2R.AppDir/");


### PR DESCRIPTION
This PR incorporates the changes from https://github.com/AM2R-Community-Developers/AM2R-Autopatcher-Linux/pull/35 into the launcher. Similarly to the `patcher.sh` script in that repo, these changes cause the launcher to do the following:
1. Patch the deprecated OpenSSL 1.0.0 dependency to point to `libcurl`
2. Wraps the `runner` binary with a script that prevents a Mesa bug from crashing the game on startup on AMD GPUs.

As discussed in the PR for `AM2R-Autopatcher-Linux`, the first item is gated behind a `PATCHOPENSSL` compile-time constant, and shouldn't affect the majority of users installing and launching the game via AppImage.