### PR TITLE
Update libgit2sharp dependency to v0.29.0

### DIFF
--- a/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
+++ b/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
@@ -31,7 +31,7 @@
 	
   <ItemGroup>
     <PackageReference Include="Eto.Forms" Version="2.8.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />

--- a/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
+++ b/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.29.0" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Since opening this issue https://github.com/AM2R-Community-Developers/AM2RLauncher/issues/79 , I noticed that the dependency for libgit2sharp hasn't been updated to the [latest version ](https://github.com/libgit2/libgit2sharp/releases), so I'm hoping this commit will fix the issue.