### PR TITLE
LibGit2Sharp v0.29.0 moved CloneOptions properties into FetchOptions

### DIFF
--- a/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
+++ b/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
@@ -31,7 +31,7 @@
 	
   <ItemGroup>
     <PackageReference Include="Eto.Forms" Version="2.8.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />

--- a/AM2RLauncher/AM2RLauncher/MainForm/MainForm.Events.cs
+++ b/AM2RLauncher/AM2RLauncher/MainForm/MainForm.Events.cs
@@ -265,7 +265,8 @@ public partial class MainForm : Form
                 EnableProgressBarAndLabel();
 
                 // Set up progressBar update method
-                CloneOptions cloneOptions = new CloneOptions { OnTransferProgress = TransferProgressHandlerMethod };
+                FetchOptions fetchOptions = new FetchOptions { OnTransferProgress = TransferProgressHandlerMethod };
+		var cloneOptions = new CloneOptions(fetchOptions);
 
                 // Try to clone
                 try

--- a/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
+++ b/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This change allows AM2RLauncher to compile (and work!) with LibGit2Sharp versions above v0.29.0
Tested, and was able to create AM2R v1.5.5 with both Github and Gitlab mirror.