### PR TITLE
Upgrade to .NET 8 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         configuration: [Release]
         include:
           - os: ubuntu-latest
             COMMAND: AM2RLauncher.Gtk -p:PublishSingleFile=true -p:DebugType=embedded -r ubuntu.18.04-x64 --no-self-contained
-            ARTIFACT: AM2RLauncher/AM2RLauncher.Gtk/bin/Release/net6.0/ubuntu.18.04-x64/publish/
-          - os: macos-13
+            ARTIFACT: AM2RLauncher/AM2RLauncher.Gtk/bin/Release/net8.0/ubuntu.18.04-x64/publish/
+          - os: macos-latest
             COMMAND: AM2RLauncher.Mac -o builds/macOS-latest
             ARTIFACT: AM2RLauncher/builds/macOS-latest
           - os: windows-latest
@@ -40,9 +40,6 @@ jobs:
     - name: Install Mac workload 
       working-directory: ./AM2RLauncher
       run: dotnet workload install macos && dotnet workload restore
-    - name: Switch XCode
-      run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app/Contents/Developer
-      if: matrix.os == 'macos-13'
     - name: Restore dependencies
       working-directory: ./AM2RLauncher
       run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         configuration: [Release]
         include:
           - os: ubuntu-latest
-            COMMAND: AM2RLauncher.Gtk -p:PublishSingleFile=true -p:DebugType=embedded -r ubuntu.18.04-x64 --no-self-contained
+            COMMAND: AM2RLauncher.Gtk -p:PublishSingleFile=true -p:DebugType=embedded -r linux-x64 --no-self-contained
             ARTIFACT: AM2RLauncher/AM2RLauncher.Gtk/bin/Release/net8.0/ubuntu.18.04-x64/publish/
           - os: macos-latest
             COMMAND: AM2RLauncher.Mac -o builds/macOS-latest

--- a/AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj
+++ b/AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj
@@ -2,7 +2,7 @@
 	
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon>icon64.ico</ApplicationIcon>
     <RollForward>LatestMajor</RollForward>
     <LangVersion>latest</LangVersion>

--- a/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
+++ b/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
@@ -13,10 +13,4 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.ComponentModel.Annotations">
-      <HintPath>..\..\..\..\..\.cache\NuGet\system.componentmodel.annotations\5.0.0\ref\netstandard2.0\System.ComponentModel.Annotations.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Fixes https://github.com/AM2R-Community-Developers/AM2RLauncher/issues/93.

This PR upstreams the downstream changes from [this patch](https://github.com/NixOS/nixpkgs/blob/19a0427a5ed527eb96053c5dd3a8a11b9cb45940/pkgs/by-name/am/am2rlauncher/dotnet-8-upgrade.patch) (credit to @GGG-Killer). I tested the upgrade on both x86 Linux and ARM64 MacOS, and (miraculously) it seems as though the application still works as expected without any other changes required. Unfortunately, I don't have a Windows PC to test these changes on; testing from other contributors would be greatly appreciated.

I also threw in a commit to try and fix the CI pipeline. It looks like the issue is with the version of MacOS that the GitHub workflow uses, hopefully updating to `macos-latest` fixes it.