### PR TITLE
Bump Eto to 2.11.0 in AM2RLauncher.Gtk

### DIFF
--- a/AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj
+++ b/AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.7.5" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AM2RLauncher/AM2RLauncher.Mac/AM2RLauncher.Mac.csproj
+++ b/AM2RLauncher/AM2RLauncher.Mac/AM2RLauncher.Mac.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.macOS" Version="2.7.5" />
+    <PackageReference Include="Eto.Platform.macOS" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AM2RLauncher/AM2RLauncher.Wpf/AM2RLauncher.Wpf.csproj
+++ b/AM2RLauncher/AM2RLauncher.Wpf/AM2RLauncher.Wpf.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.7.5" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
+++ b/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.7.5" />
+    <PackageReference Include="Eto.Forms" Version="2.11.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />


### PR DESCRIPTION
Hello!

This PR bumps Eto to version 2.11.0 in the Linux launcher. This jumps over the 2.8.0 version of Eto that caused crashes on launch (https://github.com/AM2R-Community-Developers/AM2RLauncher/issues/96). I believe this might also fix [this](https://github.com/AM2R-Community-Developers/AM2RLauncher/issues/38) bug as well, since there was a fix for native library imports related to the stack trace ([link](https://github.com/picoe/Eto/pull/2885)).

This bump ought to also allow `webkitgtk-4.1` to be used. Not sure about other distros, but 4.1 has been deprecated downstream in the NixOS monorepo.