### PR TITLE
Show an error dialog when the game fails to launch

### DIFF
--- a/AM2RLauncher/AM2RLauncher/Language/Text.Designer.cs
+++ b/AM2RLauncher/AM2RLauncher/Language/Text.Designer.cs
@@ -207,6 +207,12 @@ namespace AM2RLauncher.Language {
             }
         }
         
+        public static string GameLaunchFailed {
+            get {
+                return ResourceManager.GetString("GameLaunchFailed", resourceCulture);
+            }
+        }
+        
         public static string GithubToolTip {
             get {
                 return ResourceManager.GetString("GithubToolTip", resourceCulture);

--- a/AM2RLauncher/AM2RLauncher/Language/Text.resx
+++ b/AM2RLauncher/AM2RLauncher/Language/Text.resx
@@ -198,6 +198,9 @@
   <data name="ErrorWindowTitle" xml:space="preserve">
     <value>Error</value>
   </data>
+  <data name="GameLaunchFailed" xml:space="preserve">
+    <value>The game failed to launch.</value>
+  </data>
   <data name="GithubToolTip" xml:space="preserve">
     <value>The Community-Developers GitHub Page</value>
   </data>

--- a/AM2RLauncher/AM2RLauncher/MainForm/MainForm.Events.cs
+++ b/AM2RLauncher/AM2RLauncher/MainForm/MainForm.Events.cs
@@ -469,7 +469,8 @@ public partial class MainForm : Form
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show($"{Text.UnhandledException}\n*****Stack Trace*****\n\n{ex}", Text.ErrorWindowTitle, MessageBoxType.Error);
+                    log.Error(ex.Message);
+                    MessageBox.Show($"{Text.GameLaunchFailed}\n\n{ex.Message}", Text.ErrorWindowTitle, MessageBoxType.Error);
                 }
 
                 ShowInTaskbar = true;

--- a/AM2RLauncher/AM2RLauncherLib/Profile.cs
+++ b/AM2RLauncher/AM2RLauncherLib/Profile.cs
@@ -738,6 +738,7 @@ public static class Profile
         string gameDirectory = $"{Core.ProfilesPath}/{profile.Name}";
 
         log.Info($"Launching game profile {profile.Name}.");
+        int exitCode = 0;
         if (OS.IsWindows)
         {
             // Sets the arguments to empty, or to the profiles' logs folder to create time based logs.
@@ -777,6 +778,7 @@ public static class Profile
             process.Start();
             Core.SetForegroundWindow(process.MainWindowHandle);
             process.WaitForExit();
+            exitCode = process.ExitCode;
         }
         else if (OS.IsLinux)
         {
@@ -847,6 +849,7 @@ public static class Profile
                 process.BeginErrorReadLine();
             }
             process.WaitForExit();
+            exitCode = process.ExitCode;
         }
         else if (OS.IsMac)
         {
@@ -882,10 +885,19 @@ public static class Profile
             using Process process = new Process { StartInfo = processStartInfo };
             process.Start();
             process.WaitForExit();
+            exitCode = process.ExitCode;
         }
         else
             log.Error($"{OS.Name} cannot run games!");
 
         log.Info($"Profile {profile.Name} process exited.");
+
+        if (exitCode != 0)
+        {
+            string message = $"Game process for profile \"{profile.Name}\" exited with code {exitCode}, it likely failed to launch.";
+            if (useLogging)
+                message += $" Check the log file for more details: {logFile}";
+            throw new Exception(message);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `Profile.RunGame` never checked the game process's exit code, so if it crashed immediately after starting (e.g. a missing shared library like `libopenal.so.1`), the launcher silently returned to the main screen with zero feedback — even though the failure reason was already being written to the profile's own log file.
- `RunGame` now throws when the process exits with a non-zero code, and the Play button handler in `MainForm.Events.cs` shows that in an error dialog (new `GameLaunchFailed` string) instead of swallowing it.

## Test plan
- [x] Built and ran `AM2RLauncher.Gtk` from source (Debug and a `dotnet publish -r linux-x64` Release build) on Arch Linux.
- [x] Verified the normal Play flow is unaffected (game launches and runs fine when everything is present).
- [x] Verified the new dialog by temporarily swapping the profile's `AM2R.AppImage` for a stub script that exits non-zero — confirms the "game failed to launch" dialog now appears immediately instead of the launcher silently un-minimizing with no message.
- [x] Verified with the profile debug-log checkbox both on and off.